### PR TITLE
Use time_entries/current endpoint for running time-entries

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -12,7 +12,7 @@ pub struct ApiClient {
 
 impl ApiClient {
     pub fn from_credentials(credentials: credentials::Credentials) -> Result<ApiClient, Box<dyn std::error::Error>> {
-        
+
         let auth_string = credentials.api_token + ":api_token";
         let header_content = "Basic ".to_string() + base64::encode(auth_string).as_str();
         let mut headers = header::HeaderMap::new();
@@ -25,13 +25,19 @@ impl ApiClient {
             base_url: "https://track.toggl.com/api/v9".to_string()
         });
     }
-    
+
     pub async fn get_user(&self) -> Result<User, Box<dyn std::error::Error>> {
         let url = format!("{}/me", self.base_url);
         let result = self.get::<User>(url).await?;
         return Ok(result);
     }
-    
+
+    pub async fn get_running_time_entry(&self) -> Result<Option<TimeEntry>, Box<dyn std::error::Error>> {
+        let url = format!("{}/me/time_entries/current", self.base_url);
+        let result = self.get::<Option<TimeEntry>>(url).await?;
+        return Ok(result);
+    }
+
     pub async fn get_time_entries(&self) -> Result<Vec<TimeEntry>, Box<dyn std::error::Error>> {
         let url = format!("{}/me/time_entries", self.base_url);
         let result = self.get::<Vec<TimeEntry>>(url).await?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,7 +11,6 @@ use arguments::Command::Running;
 use arguments::Command::Stop;
 use arguments::Command::Start;
 use credentials::Credentials;
-use models::TimeEntry;
 use structopt::StructOpt;
 
 #[tokio::main]
@@ -21,7 +20,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 pub async fn execute_subcommand(command: Option<Command>) -> Result<(), Box<dyn std::error::Error>> {
-    
+
     match command {
         None => ensure_authentication(display_running_time_entry).await,
         Some(subcommand) => match subcommand {
@@ -66,11 +65,11 @@ async fn authenticate(api_client: ApiClient) {
 }
 
 async fn display_running_time_entry(api_client: ApiClient) {
-    let time_entries = api_client.get_time_entries().await;
-    match time_entries {
+    let running_time_entry = api_client.get_running_time_entry().await;
+    match running_time_entry {
         Err(error) => println!("{:?}", error),
-        Ok(time_entries) => {
-            match get_running_time_entry(time_entries) {
+        Ok(running_time_entry) => {
+            match running_time_entry {
                 None => println!("No time entry is running at the moment"),
                 Some(running_time_entry) => println!("{}", running_time_entry.description)
             }
@@ -79,26 +78,19 @@ async fn display_running_time_entry(api_client: ApiClient) {
 }
 
 async fn stop_running_time_entry(api_client: ApiClient) {
-    let time_entries = api_client.get_time_entries().await;
-    match time_entries {
+    let running_time_entry = api_client.get_running_time_entry().await;
+    match running_time_entry {
         Err(error) => println!("{:?}", error),
-        Ok(time_entries) => {
-            match get_running_time_entry(time_entries) {
+        Ok(running_time_entry) => {
+            match running_time_entry {
                 None => println!("No time entry is running at the moment"),
-                Some(running_time_entry) => {
-                    match api_client.stop_time_entry(running_time_entry).await {
+                Some(time_entry) => {
+                    match api_client.stop_time_entry(time_entry).await {
                         Err(stop_error) => println!("{:?}", stop_error),
                         Ok(_) => println!("Time entry stopped successfully")
                     }
                 }
             }
         }
-    }
-}
-
-fn get_running_time_entry(time_entries: Vec<TimeEntry>) -> Option<TimeEntry> {
-    return match time_entries.iter().find(|te| te.stop.is_none()) {
-        None => None,
-        Some(te) => Some(te.clone())
     }
 }


### PR DESCRIPTION
- Add current time-entry endpoint.
- Save on the precious bandwith and serialization!