### PR TITLE
⚠️ Simplify code by using Result

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -1,50 +1,44 @@
 use crate::credentials;
 use crate::models;
 use chrono::Utc;
-use models::{TimeEntry, User};
+use models::{TimeEntry, User, ResultWithDefaultError};
 use reqwest::{Client, header};
 use serde::{de, Serialize};
 
 pub struct ApiClient {
-    client: Client,
+    http_client: Client,
     base_url: String
 }
 
 impl ApiClient {
-    pub fn from_credentials(credentials: credentials::Credentials) -> Result<ApiClient, Box<dyn std::error::Error>> {
-
+    pub fn from_credentials(credentials: credentials::Credentials) -> ResultWithDefaultError<ApiClient> {
         let auth_string = credentials.api_token + ":api_token";
         let header_content = "Basic ".to_string() + base64::encode(auth_string).as_str();
         let mut headers = header::HeaderMap::new();
         let auth_header = header::HeaderValue::from_str(header_content.as_str())?;
         headers.insert(header::AUTHORIZATION, auth_header);
 
-        let client = Client::builder().default_headers(headers).build()?;
-        return Ok(Self {
-            client: client,
-            base_url: "https://track.toggl.com/api/v9".to_string()
-        });
+        let http_client = Client::builder().default_headers(headers).build()?;
+        let api_client = Self { http_client, base_url: "https://track.toggl.com/api/v9".to_string() };
+        return Ok(api_client);
     }
-
-    pub async fn get_user(&self) -> Result<User, Box<dyn std::error::Error>> {
+    
+    pub async fn get_user(&self) -> ResultWithDefaultError<User> {
         let url = format!("{}/me", self.base_url);
-        let result = self.get::<User>(url).await?;
-        return Ok(result);
+        return self.get::<User>(url).await;
     }
 
-    pub async fn get_running_time_entry(&self) -> Result<Option<TimeEntry>, Box<dyn std::error::Error>> {
+    pub async fn get_running_time_entry(&self) -> ResultWithDefaultError<Option<TimeEntry>> {
         let url = format!("{}/me/time_entries/current", self.base_url);
-        let result = self.get::<Option<TimeEntry>>(url).await?;
-        return Ok(result);
+        return self.get::<Option<TimeEntry>>(url).await;
     }
 
-    pub async fn get_time_entries(&self) -> Result<Vec<TimeEntry>, Box<dyn std::error::Error>> {
+    pub async fn get_time_entries(&self) -> ResultWithDefaultError<Vec<TimeEntry>> {
         let url = format!("{}/me/time_entries", self.base_url);
-        let result = self.get::<Vec<TimeEntry>>(url).await?;
-        return Ok(result);
+        return self.get::<Vec<TimeEntry>>(url).await;
     }
 
-    pub async fn stop_time_entry(&self, time_entry: TimeEntry) -> Result<TimeEntry, Box<dyn std::error::Error>> {
+    pub async fn stop_time_entry(&self, time_entry: TimeEntry) -> ResultWithDefaultError<TimeEntry> {
         let mut stopped_time_entry = time_entry.clone();
         let stop_time = Utc::now();
         let duration = stop_time - stopped_time_entry.start;
@@ -52,18 +46,17 @@ impl ApiClient {
         stopped_time_entry.duration = duration.num_seconds();
 
         let url = format!("{}/time_entries/{}", self.base_url, time_entry.id);
-        let result = self.put::<TimeEntry, TimeEntry>(url, &stopped_time_entry).await?;
-
-        return Ok(result);
+        return self.put::<TimeEntry, TimeEntry>(url, &stopped_time_entry).await;
     }
 
-    async fn get<T: de::DeserializeOwned>(&self, url: String) -> Result<T, Box<dyn std::error::Error>> {
-        let result = self.client.get(url).send().await?;
+    async fn get<T: de::DeserializeOwned>(&self, url: String) -> ResultWithDefaultError<T> {
+        let result = self.http_client.get(url).send().await?;
         let deserialized_json = result.json::<T>().await?;
         return Ok(deserialized_json);
     }
-    async fn put<T: de::DeserializeOwned, Body: Serialize>(&self, url: String, body: &Body) -> Result<T, Box<dyn std::error::Error>> {
-        let result = self.client.put(url).json(body).send().await?;
+
+    async fn put<T: de::DeserializeOwned, Body: Serialize>(&self, url: String, body: &Body) -> ResultWithDefaultError<T> {
+        let result = self.http_client.put(url).json(body).send().await?;
         let deserialized_json = result.json::<T>().await?;
         return Ok(deserialized_json);
     }

--- a/src/credentials.rs
+++ b/src/credentials.rs
@@ -1,4 +1,6 @@
+use crate::models;
 use keyring::Keyring;
+use models::ResultWithDefaultError;
 
 pub struct Credentials { pub api_token: String }
 
@@ -8,14 +10,12 @@ impl Credentials {
         return Keyring::new("togglcli", "default")
     }
 
-    pub fn read() -> Option<Credentials> {
-        return match Credentials::get_keyring().get_password() {
-            Ok(api_token) => Some(Credentials { api_token: api_token }),
-            Err(_) => None,
-        }
+    pub fn read() -> ResultWithDefaultError<Credentials> {
+        let api_token = Credentials::get_keyring().get_password()?;
+        return Ok(Credentials { api_token: api_token });
     }
 
-    pub fn persist(api_token: String) -> Result<(), Box<dyn std::error::Error>> {
+    pub fn persist(api_token: String) -> ResultWithDefaultError<()> {
         Credentials::get_keyring().set_password(api_token.as_str())?;
         return Ok(());
     }

--- a/src/models.rs
+++ b/src/models.rs
@@ -1,6 +1,8 @@
 use serde::{Deserialize, Serialize};
 use chrono::{DateTime, Utc};
 
+pub type ResultWithDefaultError<T> = Result<T, Box<dyn std::error::Error>>;
+
 #[derive(Serialize, Deserialize, Clone)]
 pub struct User {
     pub api_token: String,


### PR DESCRIPTION
This massively simplifies a lot of the code by piggybacking on the fact that we can use unwrap Results if the current method also returns a result. Basically we are using results everywhere and the result (pun intended) is less `match` boilerplate.

I also used a typealias for the result type to prevent writing `Box<dyn std::error::Error>` all the time, which is quite hard on the eyes