### PR TITLE
🕐️  Show duration of running entry

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -67,7 +67,7 @@ async fn display_running_time_entry() -> ResultWithDefaultError<()> {
     let api_client = ensure_authentication()?;
     match api_client.get_running_time_entry().await? {
         None => println!("No time entry is running at the moment"),
-        Some(running_time_entry) => println!("{}", running_time_entry.get_summary()),
+        Some(running_time_entry) => println!("{}", running_time_entry),
     }
 
     return Ok(());

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,13 +3,13 @@ mod arguments;
 mod credentials;
 mod models;
 use api::ApiClient;
-use arguments::CommandLineArguments;
 use arguments::Command;
 use arguments::Command::Auth;
 use arguments::Command::Current;
 use arguments::Command::Running;
-use arguments::Command::Stop;
 use arguments::Command::Start;
+use arguments::Command::Stop;
+use arguments::CommandLineArguments;
 use credentials::Credentials;
 use models::ResultWithDefaultError;
 use structopt::StructOpt;
@@ -26,9 +26,12 @@ pub async fn execute_subcommand(command: Option<Command>) -> ResultWithDefaultEr
         Some(subcommand) => match subcommand {
             Current | Running => display_running_time_entry().await?,
             Stop => stop_running_time_entry().await?,
-            Start { description: _, project: _ } => (),
-            Auth { api_token } => authenticate(api_token).await?
-        }
+            Start {
+                description: _,
+                project: _,
+            } => (),
+            Auth { api_token } => authenticate(api_token).await?,
+        },
     }
 
     Ok(())
@@ -40,17 +43,22 @@ fn ensure_authentication() -> ResultWithDefaultError<ApiClient> {
         Err(err) => {
             println!("Please set your API token first by calling toggl auth <API_TOKEN>.");
             println!("You can find your API token at https://track.toggl.com/profile.");
-            return Err(err)
+            return Err(err);
         }
-    }
+    };
 }
 
 async fn authenticate(api_token: String) -> ResultWithDefaultError<()> {
-    let credentials = Credentials { api_token: api_token };
+    let credentials = Credentials {
+        api_token: api_token,
+    };
     let api_client = ApiClient::from_credentials(credentials)?;
     let user = api_client.get_user().await?;
     let _credentials = Credentials::persist(user.api_token)?;
-    println!("Successfully authenticated for user with email {}", user.email);
+    println!(
+        "Successfully authenticated for user with email {}",
+        user.email
+    );
 
     return Ok(());
 }
@@ -59,7 +67,7 @@ async fn display_running_time_entry() -> ResultWithDefaultError<()> {
     let api_client = ensure_authentication()?;
     match api_client.get_running_time_entry().await? {
         None => println!("No time entry is running at the moment"),
-        Some(running_time_entry) => println!("{}", running_time_entry.description)
+        Some(running_time_entry) => println!("{}", running_time_entry.get_summary()),
     }
 
     return Ok(());

--- a/src/models.rs
+++ b/src/models.rs
@@ -1,5 +1,5 @@
+use chrono::{DateTime, Duration, Utc};
 use serde::{Deserialize, Serialize};
-use chrono::{DateTime, Utc};
 
 pub type ResultWithDefaultError<T> = Result<T, Box<dyn std::error::Error>>;
 
@@ -9,11 +9,11 @@ pub struct User {
     pub email: String,
     pub fullname: Option<String>,
     pub timezone: String,
-    pub default_workspace_id: i64
+    pub default_workspace_id: i64,
 }
 
 #[derive(Serialize, Deserialize, Clone)]
-pub struct TimeEntry {    
+pub struct TimeEntry {
     pub id: i64,
     pub description: String,
     pub start: DateTime<Utc>,
@@ -23,4 +23,39 @@ pub struct TimeEntry {
     pub workspace_id: i64,
     pub project_id: Option<i64>,
     pub task_id: Option<i64>,
+}
+
+impl TimeEntry {
+    pub fn get_description(&self) -> String {
+        match self.description.as_ref() {
+            "" => "(no description)".to_string(),
+            _ => self.description.to_string(),
+        }
+    }
+
+    pub fn get_duration(&self) -> Duration {
+        match self.stop {
+            Some(_) => Duration::seconds(self.duration),
+            None => Utc::now().signed_duration_since(self.start),
+        }
+    }
+
+    pub fn get_duration_hmmss(&self) -> String {
+        let duration = self.get_duration();
+        return format!(
+            "{}:{:02}:{:02}",
+            duration.num_hours(),
+            duration.num_minutes() % 60,
+            duration.num_seconds() % 60
+        );
+    }
+
+    pub fn get_summary(&self) -> String {
+        let summary = format!(
+            "[{}] - {}",
+            self.get_duration_hmmss(),
+            self.get_description()
+        );
+        return summary;
+    }
 }

--- a/src/models.rs
+++ b/src/models.rs
@@ -49,13 +49,15 @@ impl TimeEntry {
             duration.num_seconds() % 60
         );
     }
+}
 
-    pub fn get_summary(&self) -> String {
+impl std::fmt::Display for TimeEntry {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let summary = format!(
             "[{}] - {}",
             self.get_duration_hmmss(),
             self.get_description()
         );
-        return summary;
+        write!(f, "{}", summary)
     }
 }


### PR DESCRIPTION
- Run cargo fmt on modified files
- Show fallback description if TE description is empty
- Add helper to get `chrono::Duration` for TimeEntry

![running-te](https://user-images.githubusercontent.com/1716853/122642114-0e508180-d109-11eb-9ae4-f475df90840b.gif)
