### PR TITLE
Show time entries log

### DIFF
--- a/src/arguments.rs
+++ b/src/arguments.rs
@@ -10,6 +10,7 @@ pub struct CommandLineArguments {
 #[derive(Debug, StructOpt)]
 pub enum Command {
     Current,
+    List,
     Running,
     Stop,
     #[structopt()]

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,11 +6,12 @@ use api::ApiClient;
 use arguments::Command;
 use arguments::Command::Auth;
 use arguments::Command::Current;
+use arguments::Command::List;
 use arguments::Command::Running;
 use arguments::Command::Start;
 use arguments::Command::Stop;
 use arguments::CommandLineArguments;
-use colored::*;
+use colored::Colorize;
 use credentials::Credentials;
 use models::ResultWithDefaultError;
 use structopt::StructOpt;
@@ -32,6 +33,7 @@ pub async fn execute_subcommand(command: Option<Command>) -> ResultWithDefaultEr
                 project: _,
             } => (),
             Auth { api_token } => authenticate(api_token).await?,
+            List => display_time_entries().await?,
         },
     }
 
@@ -85,6 +87,22 @@ async fn stop_running_time_entry() -> ResultWithDefaultError<()> {
             let _stopped_time_entry = api_client.stop_time_entry(running_time_entry).await?;
             println!("{}", "Time entry stopped successfully".green());
         }
+    }
+
+    return Ok(());
+}
+
+async fn display_time_entries() -> ResultWithDefaultError<()> {
+    let api_client = ensure_authentication()?;
+    match api_client.get_time_entries().await {
+        Err(error) => println!(
+            "{}\n{}",
+            "Couldn't fetch time entries the from API".red(),
+            error
+        ),
+        Ok(time_entries) => time_entries
+            .iter()
+            .for_each(|time_entry| println!("{}", time_entry)),
     }
 
     return Ok(());

--- a/src/models.rs
+++ b/src/models.rs
@@ -1,5 +1,5 @@
 use chrono::{DateTime, Duration, Utc};
-use colored::*;
+use colored::Colorize;
 use serde::{Deserialize, Serialize};
 
 pub type ResultWithDefaultError<T> = Result<T, Box<dyn std::error::Error>>;
@@ -59,9 +59,13 @@ impl TimeEntry {
 impl std::fmt::Display for TimeEntry {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let summary = format!(
-            "[{}]{} – {}",
-            self.get_duration_hmmss().green(),
-            if self.is_running() { "*" } else { "" },
+            "[{}]{} –  {}",
+            if self.is_running() {
+                self.get_duration_hmmss().green().bold()
+            } else {
+                self.get_duration_hmmss().normal()
+            },
+            if self.is_running() { "*" } else { " " },
             self.get_description()
         );
         write!(f, "{}", summary)


### PR DESCRIPTION
## Prerequisites

Depends on #4

## What does this do?

- Add `list` command
- Show time-entries list

<img width="874" alt="Screenshot 2021-06-20 at 10 01 05" src="https://user-images.githubusercontent.com/1716853/122666584-6ee5ca00-d1ae-11eb-9ea6-1e0012193010.png">

