### PR TITLE
🛰️ Move implementation of API to a trait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -43,6 +43,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-trait"
+version = "0.1.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b98e84bbb4cbcdd97da190ba0c58a1bb0de2c1fdf67d159e192ed766aeca722"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1283,6 +1294,7 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 name = "toggl-cli"
 version = "0.1.0"
 dependencies = [
+ "async-trait",
  "base64",
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ serde_json = "1.0.48"
 reqwest = { version = "0.11", features = ["json"] }
 tokio = { version = "1", features = ["full"] }
 base64 = "0.13.0"
+async-trait = "0.1.50"
 
 # Models
 chrono = { version = "0.4.19", features = ["serde"] }

--- a/src/api.rs
+++ b/src/api.rs
@@ -1,21 +1,74 @@
 use crate::credentials;
 use crate::models;
+use async_trait::async_trait;
 use chrono::Utc;
 use models::{ResultWithDefaultError, TimeEntry, User};
 use reqwest::{header, Client};
 use serde::{de, Serialize};
 
-pub struct ApiClient {
+const CLIENT_NAME: &'static str = "github.com/heytherewill/toggl-cli";
+
+#[async_trait]
+pub trait ApiClient {
+    async fn get_user(&self) -> ResultWithDefaultError<User>;
+    async fn get_running_time_entry(&self) -> ResultWithDefaultError<Option<TimeEntry>>;
+    async fn get_time_entries(&self) -> ResultWithDefaultError<Vec<TimeEntry>>;
+    async fn start_time_entry(&self, time_entry: TimeEntry) -> ResultWithDefaultError<TimeEntry>;
+    async fn stop_time_entry(&self, time_entry: TimeEntry) -> ResultWithDefaultError<TimeEntry>;
+}
+
+pub struct V9ApiClient {
     http_client: Client,
     base_url: String,
 }
 
-const CLIENT_NAME: &'static str = "github.com/heytherewill/toggl-cli";
+#[async_trait]
+impl ApiClient for V9ApiClient {
+    async fn get_user(&self) -> ResultWithDefaultError<User> {
+        let url = format!("{}/me", self.base_url);
+        return self.get::<User>(url).await;
+    }
 
-impl ApiClient {
+    async fn get_running_time_entry(&self) -> ResultWithDefaultError<Option<TimeEntry>> {
+        let url = format!("{}/me/time_entries/current", self.base_url);
+        return self.get::<Option<TimeEntry>>(url).await;
+    }
+
+    async fn get_time_entries(&self) -> ResultWithDefaultError<Vec<TimeEntry>> {
+        let url = format!("{}/me/time_entries", self.base_url);
+        return self.get::<Vec<TimeEntry>>(url).await;
+    }
+
+    async fn start_time_entry(&self, time_entry: TimeEntry) -> ResultWithDefaultError<TimeEntry> {
+        let url = format!("{}/time_entries", self.base_url);
+        let time_entry_to_create = TimeEntry {
+            created_with: Some(CLIENT_NAME.to_string()),
+            ..time_entry
+        };
+        return self
+            .post::<TimeEntry, TimeEntry>(url, &time_entry_to_create)
+            .await;
+    }
+
+    async fn stop_time_entry(&self, time_entry: TimeEntry) -> ResultWithDefaultError<TimeEntry> {
+        let stop_time = Utc::now();
+        let stopped_time_entry = TimeEntry {
+            stop: Some(stop_time),
+            duration: (stop_time - time_entry.start).num_seconds(),
+            ..time_entry
+        };
+
+        let url = format!("{}/time_entries/{}", self.base_url, time_entry.id);
+        return self
+            .put::<TimeEntry, TimeEntry>(url, &stopped_time_entry)
+            .await;
+    }
+}
+
+impl V9ApiClient {
     pub fn from_credentials(
         credentials: credentials::Credentials,
-    ) -> ResultWithDefaultError<ApiClient> {
+    ) -> ResultWithDefaultError<V9ApiClient> {
         let auth_string = credentials.api_token + ":api_token";
         let header_content = "Basic ".to_string() + base64::encode(auth_string).as_str();
         let mut headers = header::HeaderMap::new();
@@ -28,52 +81,6 @@ impl ApiClient {
             base_url: "https://track.toggl.com/api/v9".to_string(),
         };
         return Ok(api_client);
-    }
-
-    pub async fn get_user(&self) -> ResultWithDefaultError<User> {
-        let url = format!("{}/me", self.base_url);
-        return self.get::<User>(url).await;
-    }
-
-    pub async fn get_running_time_entry(&self) -> ResultWithDefaultError<Option<TimeEntry>> {
-        let url = format!("{}/me/time_entries/current", self.base_url);
-        return self.get::<Option<TimeEntry>>(url).await;
-    }
-
-    pub async fn get_time_entries(&self) -> ResultWithDefaultError<Vec<TimeEntry>> {
-        let url = format!("{}/me/time_entries", self.base_url);
-        return self.get::<Vec<TimeEntry>>(url).await;
-    }
-
-    pub async fn start_time_entry(
-        &self,
-        time_entry: TimeEntry,
-    ) -> ResultWithDefaultError<TimeEntry> {
-        let url = format!("{}/time_entries", self.base_url);
-        let time_entry_to_create = TimeEntry {
-            created_with: Some(CLIENT_NAME.to_string()),
-            ..time_entry
-        };
-        return self
-            .post::<TimeEntry, TimeEntry>(url, &time_entry_to_create)
-            .await;
-    }
-
-    pub async fn stop_time_entry(
-        &self,
-        time_entry: TimeEntry,
-    ) -> ResultWithDefaultError<TimeEntry> {
-        let stop_time = Utc::now();
-        let stopped_time_entry = TimeEntry {
-            stop: Some(stop_time),
-            duration: (stop_time - time_entry.start).num_seconds(),
-            ..time_entry
-        };
-
-        let url = format!("{}/time_entries/{}", self.base_url, time_entry.id);
-        return self
-            .put::<TimeEntry, TimeEntry>(url, &stopped_time_entry)
-            .await;
     }
 
     async fn get<T: de::DeserializeOwned>(&self, url: String) -> ResultWithDefaultError<T> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,7 +2,7 @@ mod api;
 mod arguments;
 mod credentials;
 mod models;
-use api::ApiClient;
+use api::{ApiClient, V9ApiClient};
 use arguments::Command;
 use arguments::Command::Auth;
 use arguments::Command::Continue;
@@ -43,9 +43,9 @@ pub async fn execute_subcommand(command: Option<Command>) -> ResultWithDefaultEr
     Ok(())
 }
 
-fn ensure_authentication() -> ResultWithDefaultError<ApiClient> {
+fn ensure_authentication() -> ResultWithDefaultError<impl ApiClient> {
     return match Credentials::read() {
-        Ok(credentials) => ApiClient::from_credentials(credentials),
+        Ok(credentials) => V9ApiClient::from_credentials(credentials),
         Err(err) => {
             println!(
                 "{}\n{} {}",
@@ -60,7 +60,7 @@ fn ensure_authentication() -> ResultWithDefaultError<ApiClient> {
 
 async fn authenticate(api_token: String) -> ResultWithDefaultError<()> {
     let credentials = Credentials { api_token };
-    let api_client = ApiClient::from_credentials(credentials)?;
+    let api_client = V9ApiClient::from_credentials(credentials)?;
     let user = api_client.get_user().await?;
     let _credentials = Credentials::persist(user.api_token)?;
     println!(


### PR DESCRIPTION
Closes #13 

This splits the implementation of the API from its definition. We now have a `V9ApiClient` which implements the `ApiClient` trait. This separation is meant to simplify testing and what-not