### PR TITLE
▶️ Add Start command

### DIFF
--- a/src/arguments.rs
+++ b/src/arguments.rs
@@ -25,7 +25,9 @@ pub enum Command {
         #[structopt(short, long)]
         description: String,
         #[structopt(short, long)]
-        project: String,
+        project: Option<String>,
+        #[structopt(short, long)]
+        billable: bool,
     },
     Continue,
 }

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -2,4 +2,5 @@ pub mod auth;
 pub mod cont;
 pub mod list;
 pub mod running;
+pub mod start;
 pub mod stop;

--- a/src/commands/start.rs
+++ b/src/commands/start.rs
@@ -1,0 +1,60 @@
+use crate::api;
+use crate::models;
+use api::ApiClient;
+use chrono::Utc;
+use colored::Colorize;
+use models::ResultWithDefaultError;
+use models::TimeEntry;
+
+pub struct StartCommand;
+
+impl StartCommand {
+    pub async fn execute(
+        api_client: impl ApiClient,
+        billable: bool,
+        description: String,
+    ) -> ResultWithDefaultError<()> {
+        let running_entry_stop_time = Utc::now();
+        match api_client.get_running_time_entry().await {
+            Err(error) => {
+                println!(
+                    "{} {:?}",
+                    "Couldn't retrieve running time entry.".red(),
+                    error
+                );
+                return Ok(());
+            }
+            Ok(value) => {
+                if let Some(time_entry) = value {
+                    if let Err(stop_error) = api_client
+                        .update_time_entry(
+                            time_entry.as_stopped_time_entry(running_entry_stop_time),
+                        )
+                        .await
+                    {
+                        println!(
+                            "{} {:?}",
+                            "Couldn't stop running time entry.".red(),
+                            stop_error
+                        );
+                        return Ok(());
+                    }
+                    println!("Running time entry stopped")
+                }
+            }
+        }
+
+        let started_entry = api_client
+            .create_time_entry(TimeEntry {
+                billable,
+                description,
+                workspace_id: (api_client.get_user().await?).default_workspace_id,
+                ..Default::default()
+            })
+            .await?;
+
+        println!("{}\n{}", "Time entry started".green(), started_entry);
+
+        Ok(())
+    }
+}

--- a/src/commands/start.rs
+++ b/src/commands/start.rs
@@ -26,12 +26,13 @@ impl StartCommand {
             }
             Ok(value) => {
                 if let Some(time_entry) = value {
-                    if let Err(stop_error) = api_client
+                    let stopped_time_entry = api_client
                         .update_time_entry(
                             time_entry.as_stopped_time_entry(running_entry_stop_time),
                         )
-                        .await
-                    {
+                        .await;
+
+                    if let Err(stop_error) = stopped_time_entry {
                         println!(
                             "{} {:?}",
                             "Couldn't stop running time entry.".red(),
@@ -39,7 +40,11 @@ impl StartCommand {
                         );
                         return Ok(());
                     }
-                    println!("Running time entry stopped")
+                    println!(
+                        "{}\n{}",
+                        "Running time entry stopped".yellow(),
+                        stopped_time_entry.unwrap()
+                    );
                 }
             }
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,6 +19,7 @@ use commands::auth::AuthenticationCommand;
 use commands::cont::ContinueCommand;
 use commands::list::ListCommand;
 use commands::running::RunningTimeEntryCommand;
+use commands::start::StartCommand;
 use commands::stop::StopCommand;
 use credentials::{Credentials, CredentialsStorage, KeyringStorage};
 use keyring::Keyring;
@@ -40,9 +41,10 @@ pub async fn execute_subcommand(command: Option<Command>) -> ResultWithDefaultEr
             List { number } => ListCommand::execute(get_api_client()?, number).await?,
             Current | Running => RunningTimeEntryCommand::execute(get_api_client()?).await?,
             Start {
-                description: _,
+                billable,
+                description,
                 project: _,
-            } => (),
+            } => StartCommand::execute(get_api_client()?, billable, description).await?,
             Auth { api_token } => {
                 let credentials = Credentials { api_token };
                 let api_client = V9ApiClient::from_credentials(credentials)?;

--- a/src/models.rs
+++ b/src/models.rs
@@ -76,6 +76,24 @@ impl TimeEntry {
     }
 }
 
+impl Default for TimeEntry {
+    fn default() -> Self {
+        let start = Utc::now();
+        Self {
+            id: -1,
+            created_with: Some(constants::CLIENT_NAME.to_string()),
+            billable: false,
+            description: "".to_string(),
+            duration: -start.timestamp(),
+            project_id: None,
+            start,
+            stop: None,
+            task_id: None,
+            workspace_id: -1,
+        }
+    }
+}
+
 impl std::fmt::Display for TimeEntry {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let summary = format!(


### PR DESCRIPTION
## What does this do?

![Capture 2021-06-21 at 21 08 57](https://user-images.githubusercontent.com/6432028/122821568-ed3c8c00-d2d4-11eb-9b87-279397359542.png)

* Add `start` command. Description is required, billable is optional.
* Stop running entry before continuing in the `continue` command

```
toggl-cli start -d "Description"
```

We've gotta stop the running entry as the API doesn't do it for us.

The code to "get and stop running entry if there is one" would be a good candidate for a common crate later



