### PR TITLE
Add interactive continue

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -52,6 +52,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrayvec"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
+
+[[package]]
 name = "async-stream"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -101,10 +107,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
+name = "base-x"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4521f3e3d031370679b3b140beb36dfe4801b09ac77e30c61941f97df3ef28b"
+
+[[package]]
 name = "base64"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
+
+[[package]]
+name = "beef"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6736e2428df2ca2848d846c43e88745121a6654696e349ce0054a420815a7409"
 
 [[package]]
 name = "bitflags"
@@ -163,6 +181,12 @@ checksum = "4a72c244c1ff497a746a7e1fb3d14bd08420ecda70c8f25c7112f2781652d787"
 
 [[package]]
 name = "cfg-if"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
+
+[[package]]
+name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
@@ -177,7 +201,7 @@ dependencies = [
  "num-integer",
  "num-traits",
  "serde",
- "time",
+ "time 0.1.44",
  "winapi",
 ]
 
@@ -199,7 +223,7 @@ dependencies = [
  "ansi_term",
  "atty",
  "bitflags",
- "strsim",
+ "strsim 0.8.0",
  "textwrap",
  "unicode-width",
  "vec_map",
@@ -215,6 +239,12 @@ dependencies = [
  "lazy_static",
  "winapi",
 ]
+
+[[package]]
+name = "const_fn"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f92cfa0fd5690b3cf8c1ef2cabbd9b7ef22fa53cf5e1f92b05103f6d5d1cf6e7"
 
 [[package]]
 name = "core-foundation"
@@ -250,11 +280,100 @@ checksum = "ea221b5284a47e40033bf9b66f35f984ec0ea2931eb03505246cd27a963f981b"
 
 [[package]]
 name = "cpufeatures"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed00c67cb5d0a7d64a44f6ad2668db7e7530311dd53ea79bcd4fb022c64911c8"
+checksum = "66c99696f6c9dd7f35d486b9d04d7e6e202aa3e8c40d553f2fdf5e7e0c6a71ef"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "crossbeam"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ae5588f6b3c3cb05239e90bd110f257254aecd01e4635400391aeae07497845"
+dependencies = [
+ "cfg-if 1.0.0",
+ "crossbeam-channel 0.5.1",
+ "crossbeam-deque",
+ "crossbeam-epoch",
+ "crossbeam-queue",
+ "crossbeam-utils 0.8.5",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b153fe7cbef478c567df0f972e02e6d736db11affe43dfc9c56a9374d1adfb87"
+dependencies = [
+ "crossbeam-utils 0.7.2",
+ "maybe-uninit",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06ed27e177f16d65f0f0c22a213e17c696ace5dd64b14258b52f9417ccb52db4"
+dependencies = [
+ "cfg-if 1.0.0",
+ "crossbeam-utils 0.8.5",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94af6efb46fef72616855b036a624cf27ba656ffc9be1b9a3c931cfc7749a9a9"
+dependencies = [
+ "cfg-if 1.0.0",
+ "crossbeam-epoch",
+ "crossbeam-utils 0.8.5",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ec02e091aa634e2c3ada4a392989e7c3116673ef0ac5b72232439094d73b7fd"
+dependencies = [
+ "cfg-if 1.0.0",
+ "crossbeam-utils 0.8.5",
+ "lazy_static",
+ "memoffset",
+ "scopeguard",
+]
+
+[[package]]
+name = "crossbeam-queue"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b10ddc024425c88c2ad148c1b0fd53f4c6d38db9697c9f1588381212fa657c9"
+dependencies = [
+ "cfg-if 1.0.0",
+ "crossbeam-utils 0.8.5",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3c7c73a2d1e9fc0886a08b93e98eb643461230d5f1925e4036204d5f2e261a8"
+dependencies = [
+ "autocfg",
+ "cfg-if 0.1.10",
+ "lazy_static",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d82cfc11ce7f2c3faef78d8a684447b40d503d9681acebed6cb728d45940c4db"
+dependencies = [
+ "cfg-if 1.0.0",
+ "lazy_static",
 ]
 
 [[package]]
@@ -268,12 +387,82 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d706e75d87e35569db781a9b5e2416cff1236a47ed380831f959382ccd5f858"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0c960ae2da4de88a91b2d920c2a7233b400bc33cb28453a2987822d8392519b"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim 0.9.3",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b5a2f4ac4969822c62224815d069952656cadc7084fdca9751e6d959189b72"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "dbus"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4a0c10ea61042b7555729ab0608727bbbb06ce709c11e6047cfa4e10f6d052d"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "defer-drop"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18ae055245e14ed411f56dddf2a78caae87c25d9d6a18fb61f398a596cad77b4"
+dependencies = [
+ "crossbeam-channel 0.4.4",
+ "once_cell",
+]
+
+[[package]]
+name = "derive_builder"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2658621297f2cf68762a6f7dc0bb7e1ff2cfd6583daef8ee0fed6f7ec468ec0"
+dependencies = [
+ "darling",
+ "derive_builder_core",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "derive_builder_core"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2791ea3e372c8495c0bc2033991d76b512cd799d07491fbd6890124db9458bef"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -292,10 +481,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13aea89a5c93364a98e9b37b2fa237effbb694d5cfe01c5b70941f7eb087d5e3"
+dependencies = [
+ "cfg-if 0.1.10",
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03d86534ed367a67548dc68113a0f5db55432fdfbb6e6f9d77704397d95d5780"
+dependencies = [
+ "libc",
+ "redox_users",
+ "winapi",
+]
+
+[[package]]
+name = "discard"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "212d0f5754cb6769937f4501cc0e67f4f4483c8d2c3e1e922ee9edbe4ab4c7c0"
+
+[[package]]
 name = "downcast"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4bb454f0228b18c7f4c3b0ebbee346ed9c52e7443b0999cd543ff3571205701d"
+
+[[package]]
+name = "either"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
 name = "encoding_rs"
@@ -303,7 +525,20 @@ version = "0.8.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80df024fbc5ac80f87dfef0d9f5209a252f2a497f7f42944cff24d8253cac065"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a19187fea3ac7e84da7dacf48de0c45d63c6a76f9490dae389aead16c243fce3"
+dependencies = [
+ "atty",
+ "humantime",
+ "log",
+ "regex",
+ "termcolor",
 ]
 
 [[package]]
@@ -393,6 +628,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "fuzzy-matcher"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54614a3312934d066701a80f20f15fa3b56d67ac7722b39eea5b4c9dd1d66c94"
+dependencies = [
+ "thread_local",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -408,7 +652,7 @@ version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "libc",
  "wasi 0.9.0+wasi-snapshot-preview1",
 ]
@@ -419,7 +663,7 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fcd999463524c52659517fe2cea98493cfe485d10565e7b0fb07dbba7ad2753"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "libc",
  "wasi 0.10.0+wasi-snapshot-preview1",
 ]
@@ -460,9 +704,9 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.18"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "322f4de77956e22ed0e5032c359a0f1273f1f7f0d79bfa3b8ffbc730d7fbcc5c"
+checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
 dependencies = [
  "libc",
 ]
@@ -522,6 +766,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6456b8a6c8f33fee7d958fcd1b60d55b11940a79e63ae87013e6d22e26034440"
 
 [[package]]
+name = "humantime"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
+
+[[package]]
 name = "hyper"
 version = "0.14.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -559,6 +809,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -585,7 +841,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61124eeebbd69b8190558df225adf7e4caafce0d743919e5d6b19652314ec5ec"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
 ]
 
 [[package]]
@@ -648,7 +904,7 @@ version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
 ]
 
 [[package]]
@@ -658,10 +914,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
 
 [[package]]
+name = "maybe-uninit"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00"
+
+[[package]]
 name = "memchr"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b16bd47d9e329435e309c58469fe0791c2d0d1ba96ec0954152a5ae2b04387dc"
+
+[[package]]
+name = "memoffset"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59accc507f1338036a0477ef61afdae33cde60840f4dfe481319ce3ad116ddf9"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "mime"
@@ -697,7 +968,7 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "18d614ad23f9bb59119b8b5670a85c7ba92c5e9adf4385c81ea00c51c8be33d5"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "downcast",
  "fragile",
  "lazy_static",
@@ -712,7 +983,7 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5dd4234635bca06fc96c7368d038061e0aae1b00a764dc817e900dc974e3deea"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "proc-macro2",
  "quote",
  "syn",
@@ -734,6 +1005,31 @@ dependencies = [
  "security-framework 2.3.1",
  "security-framework-sys 2.3.0",
  "tempfile",
+]
+
+[[package]]
+name = "nix"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c722bee1037d430d0f8e687bbdbf222f27cc6e4e68d5caf630857bb2b6dbdce"
+dependencies = [
+ "bitflags",
+ "cc",
+ "cfg-if 0.1.10",
+ "libc",
+ "void",
+]
+
+[[package]]
+name = "nix"
+version = "0.19.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2ccba0cfe4fdf15982d1674c69b1fd80bad427d293849982668dfe454bd61f2"
+dependencies = [
+ "bitflags",
+ "cc",
+ "cfg-if 1.0.0",
+ "libc",
 ]
 
 [[package]]
@@ -856,7 +1152,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "549430950c79ae24e6d02e0b7404534ecf311d94cc9f861e9e4020187d13d885"
 dependencies = [
  "bitflags",
- "cfg-if",
+ "cfg-if 1.0.0",
  "foreign-types",
  "libc",
  "once_cell",
@@ -871,9 +1167,9 @@ checksum = "28988d872ab76095a6e6ac88d99b54fd267702734fd7ffe610ca27f533ddb95a"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.64"
+version = "0.9.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "209efc2fe0e980c8849efacdb567f975a1c80245c4f6980d6f012733bfa851af"
+checksum = "7a7907e3bfa08bb85105209cdfcb6c63d109f8f6c1ed6ca318fff5c1853fbc1d"
 dependencies = [
  "autocfg",
  "cc",
@@ -899,7 +1195,7 @@ version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa7a782938e745763fe6907fc6ba86946d72f49fe7e21de074e08128a99fb018"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "instant",
  "libc",
  "redox_syscall",
@@ -915,9 +1211,9 @@ checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc0e1f259c92177c30a4c9d177246edd0a3568b25756a977d0632cf8fa37e905"
+checksum = "8d31d11c69a6b52a174b42bdc0c30e5e11670f90788b2c471c31c1d17d449443"
 
 [[package]]
 name = "pin-utils"
@@ -989,6 +1285,12 @@ dependencies = [
  "quote",
  "version_check",
 ]
+
+[[package]]
+name = "proc-macro-hack"
+version = "0.5.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
 
 [[package]]
 name = "proc-macro2"
@@ -1090,12 +1392,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "rayon"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c06aca804d41dbc8ba42dfd964f0d01334eceb64314b9ecf7c5fad5188a06d90"
+dependencies = [
+ "autocfg",
+ "crossbeam-deque",
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d78120e2c850279833f1dd3582f730c4ab53ed95aeaaaa862a2a5c71b1656d8e"
+dependencies = [
+ "crossbeam-channel 0.5.1",
+ "crossbeam-deque",
+ "crossbeam-utils 0.8.5",
+ "lazy_static",
+ "num_cpus",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ab49abadf3f9e1c4bc499e8845e152ad87d2ad2d30371841171169e9d75feee"
 dependencies = [
  "bitflags",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "528532f3d801c87aec9def2add9ca802fe569e44a544afe633765267840abe64"
+dependencies = [
+ "getrandom 0.2.3",
+ "redox_syscall",
 ]
 
 [[package]]
@@ -1126,9 +1463,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.11.3"
+version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2296f2fac53979e8ccbc4a1136b25dcefd37be9ed7e4a1f6b05a6029c84ff124"
+checksum = "246e9f61b9bb77df069a947682be06e31ac43ea37862e244a69f177694ea6d22"
 dependencies = [
  "base64",
  "bytes",
@@ -1157,6 +1494,15 @@ dependencies = [
  "wasm-bindgen-futures",
  "web-sys",
  "winreg",
+]
+
+[[package]]
+name = "rustc_version"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
+dependencies = [
+ "semver",
 ]
 
 [[package]]
@@ -1244,6 +1590,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "semver"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
+dependencies = [
+ "semver-parser",
+]
+
+[[package]]
+name = "semver-parser"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
+
+[[package]]
 name = "serde"
 version = "1.0.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1287,17 +1648,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2579985fda508104f7587689507983eadd6a6e84dd35d6d115361f530916fa0d"
+
+[[package]]
 name = "sha2"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b362ae5752fd2137731f9fa25fd4d9058af34666ca1966fb969119cc35719f12"
 dependencies = [
  "block-buffer",
- "cfg-if",
+ "cfg-if 1.0.0",
  "cpufeatures",
  "digest",
  "opaque-debug",
 ]
+
+[[package]]
+name = "shlex"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fdf1b9db47230893d76faad238fd6097fd6d6a9245cd7a4d90dbd639536bbd2"
 
 [[package]]
 name = "signal-hook-registry"
@@ -1306,6 +1679,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e51e73328dc4ac0c7ccbda3a494dfa03df1de2f46018127f60c693f2648455b0"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "skim"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b9d19f904221fab15163486d2ce116cb86e60296470bb4e956d6687f04ebbb4"
+dependencies = [
+ "atty",
+ "beef",
+ "bitflags",
+ "chrono",
+ "clap",
+ "crossbeam",
+ "defer-drop",
+ "derive_builder",
+ "env_logger",
+ "fuzzy-matcher",
+ "lazy_static",
+ "log",
+ "nix 0.19.1",
+ "rayon",
+ "regex",
+ "shlex",
+ "time 0.2.27",
+ "timer",
+ "tuikit",
+ "unicode-width",
+ "vte",
 ]
 
 [[package]]
@@ -1331,10 +1733,74 @@ dependencies = [
 ]
 
 [[package]]
+name = "standback"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e113fb6f3de07a243d434a56ec6f186dfd51cb08448239fe7bcae73f87ff28ff"
+dependencies = [
+ "version_check",
+]
+
+[[package]]
+name = "stdweb"
+version = "0.4.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d022496b16281348b52d0e30ae99e01a73d737b2f45d38fed4edf79f9325a1d5"
+dependencies = [
+ "discard",
+ "rustc_version",
+ "stdweb-derive",
+ "stdweb-internal-macros",
+ "stdweb-internal-runtime",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "stdweb-derive"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c87a60a40fccc84bef0652345bbbbbe20a605bf5d0ce81719fc476f5c03b50ef"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_derive",
+ "syn",
+]
+
+[[package]]
+name = "stdweb-internal-macros"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58fa5ff6ad0d98d1ffa8cb115892b6e69d67799f6763e162a1c9db421dc22e11"
+dependencies = [
+ "base-x",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "sha1",
+ "syn",
+]
+
+[[package]]
+name = "stdweb-internal-runtime"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "213701ba3370744dcd1a12960caa4843b3d68b4d1c0a5d575e0d65b2ee9d16c0"
+
+[[package]]
 name = "strsim"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
+
+[[package]]
+name = "strsim"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6446ced80d6c486436db5c078dde11a9f73d42b57fb273121e160b84f63d894c"
 
 [[package]]
 name = "structopt"
@@ -1383,12 +1849,31 @@ version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dac1c663cfc93810f88aed9b8941d48cabf856a1b111c29a40439018d870eb22"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "libc",
  "rand 0.8.4",
  "redox_syscall",
  "remove_dir_all",
  "winapi",
+]
+
+[[package]]
+name = "term"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0863a3345e70f61d613eab32ee046ccd1bcc5f9105fe402c61fcd0c13eeb8b5"
+dependencies = [
+ "dirs",
+ "winapi",
+]
+
+[[package]]
+name = "termcolor"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dfed899f0eb03f32ee8c6a0aabdb8a7949659e3466561fc0adf54e26d88c5f4"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]
@@ -1401,6 +1886,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8018d24e04c95ac8790716a5987d0fec4f8b27249ffa0f7d33f1369bdfb88cbd"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
 name = "time"
 version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1409,6 +1903,53 @@ dependencies = [
  "libc",
  "wasi 0.10.0+wasi-snapshot-preview1",
  "winapi",
+]
+
+[[package]]
+name = "time"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4752a97f8eebd6854ff91f1c1824cd6160626ac4bd44287f7f4ea2035a02a242"
+dependencies = [
+ "const_fn",
+ "libc",
+ "standback",
+ "stdweb",
+ "time-macros",
+ "version_check",
+ "winapi",
+]
+
+[[package]]
+name = "time-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "957e9c6e26f12cb6d0dd7fc776bb67a706312e7299aed74c8dd5b17ebb27e2f1"
+dependencies = [
+ "proc-macro-hack",
+ "time-macros-impl",
+]
+
+[[package]]
+name = "time-macros-impl"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd3c141a1b43194f3f56a1411225df8646c55781d5f26db825b3d98507eb482f"
+dependencies = [
+ "proc-macro-hack",
+ "proc-macro2",
+ "quote",
+ "standback",
+ "syn",
+]
+
+[[package]]
+name = "timer"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31d42176308937165701f50638db1c31586f183f1aab416268216577aec7306b"
+dependencies = [
+ "chrono",
 ]
 
 [[package]]
@@ -1440,6 +1981,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "skim",
  "structopt",
  "tokio",
  "tokio-test",
@@ -1536,7 +2078,7 @@ version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09adeb8c97449311ccd28a427f96fb563e7fd31aabf994189879d9da2394b89d"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "pin-project-lite",
  "tracing-core",
 ]
@@ -1561,6 +2103,20 @@ name = "try-lock"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
+
+[[package]]
+name = "tuikit"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c628cfc5752254a33ebccf73eb79ef6508fab77de5d5ef76246b5e45010a51f"
+dependencies = [
+ "bitflags",
+ "lazy_static",
+ "log",
+ "nix 0.14.1",
+ "term",
+ "unicode-width",
+]
 
 [[package]]
 name = "typenum"
@@ -1617,6 +2173,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "utf8parse"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "936e4b492acfd135421d8dca4b1aa80a7bfc26e702ef3af710e0752684df5372"
+
+[[package]]
 name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1633,6 +2195,33 @@ name = "version_check"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
+
+[[package]]
+name = "void"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
+
+[[package]]
+name = "vte"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e7745610024d50ab1ebfa41f8f8ee361c567f7ab51032f93cc1cc4cbf0c547a"
+dependencies = [
+ "arrayvec",
+ "utf8parse",
+ "vte_generate_state_changes",
+]
+
+[[package]]
+name = "vte_generate_state_changes"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d257817081c7dffcdbab24b9e62d2def62e2ff7d00b1c20062551e6cccc145ff"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
 
 [[package]]
 name = "want"
@@ -1662,7 +2251,7 @@ version = "0.2.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d54ee1d4ed486f78874278e63e4069fc1ab9f6a18ca492076ffb90c5eb2997fd"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "serde",
  "serde_json",
  "wasm-bindgen-macro",
@@ -1689,7 +2278,7 @@ version = "0.4.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5fba7978c679d53ce2d0ac80c8c175840feb849a161664365d1287b41f2e67f1"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "js-sys",
  "wasm-bindgen",
  "web-sys",
@@ -1749,6 +2338,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,6 @@ structopt = { version = "0.3" }
 
 # Terminal utilities
 colored = "2.0.0"
-skim = "0.9.4"
 
 # Storage
 keyring = "0.10.1"
@@ -31,3 +30,6 @@ chrono = { version = "0.4.19", features = ["serde"] }
 # Testing
 mockall = "0.9.1"
 tokio-test = "0.4.2"
+
+[target.'cfg(unix)'.dependencies]
+skim = "0.9.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,10 @@ edition = "2018"
 # Argument parsing
 clap = "2.27.1"
 structopt = { version = "0.3" }
+
+# Terminal utilities
 colored = "2.0.0"
+skim = "0.9.4"
 
 # Storage
 keyring = "0.10.1"

--- a/src/arguments.rs
+++ b/src/arguments.rs
@@ -29,5 +29,8 @@ pub enum Command {
         #[structopt(short, long)]
         billable: bool,
     },
-    Continue,
+    Continue {
+        #[structopt(short, long)]
+        interactive: bool,
+    },
 }

--- a/src/commands/auth.rs
+++ b/src/commands/auth.rs
@@ -59,7 +59,7 @@ mod tests {
             .expect_get_user()
             .returning(move || Ok(user.clone()));
 
-        return api_client;
+        api_client
     }
 
     fn create_failing_api_client() -> MockApiClient {
@@ -68,13 +68,13 @@ mod tests {
             .expect_get_user()
             .returning(|| Err(Box::new(ApiError::Network)));
 
-        return api_client;
+        api_client
     }
 
     fn create_working_credentials_storage() -> MockCredentialsStorage {
         let mut credentials_storage = MockCredentialsStorage::new();
         credentials_storage.expect_persist().returning(|_| Ok(()));
-        return credentials_storage;
+        credentials_storage
     }
 
     fn create_failing_credentials_storage() -> MockCredentialsStorage {
@@ -82,7 +82,7 @@ mod tests {
         credentials_storage
             .expect_persist()
             .returning(|_| Err(Box::new(StorageError::Write)));
-        return credentials_storage;
+        credentials_storage
     }
 
     #[tokio::test]
@@ -117,7 +117,7 @@ mod tests {
             MOCK_EMAIL.green().bold()
         );
         let actual_output = String::from_utf8(output)
-            .expect(format!("empty output when {} was expected", expected_output).as_str());
+            .unwrap_or_else(|_| panic!("empty output when {} was expected", expected_output));
 
         assert_eq!(expected_output, actual_output);
     }

--- a/src/commands/cont.rs
+++ b/src/commands/cont.rs
@@ -45,8 +45,12 @@ impl ContinueCommand {
         }
 
         let time_entries = api_client.get_time_entries().await?;
+        if time_entries.is_empty() {
+            println!("{}", "No time entries in last 90 days".red())
+        }
+
         match get_time_to_continue(time_entries, running_time_entry, interactive) {
-            None => println!("{}", "No time entries in last 90 days".red()),
+            None => println!("{}", "No time entry to continue".red()),
             Some(time_entry) => {
                 let start_time = Utc::now();
                 let time_entry_to_create = time_entry.as_running_time_entry(start_time);
@@ -103,7 +107,10 @@ fn get_time_entry_from_user(time_entries: Vec<TimeEntry>) -> Option<TimeEntry> {
 
     Skim::run_with(&options, Some(source))
         .map(|output| match output.is_abort {
-            true => Vec::new(),
+            true => {
+                println!("{}", "Operation cancelled".red());
+                Vec::new()
+            },
             false => output.selected_items,
         })
         .map(|selected_items| {

--- a/src/commands/cont.rs
+++ b/src/commands/cont.rs
@@ -110,7 +110,7 @@ fn get_time_entry_from_user(time_entries: Vec<TimeEntry>) -> Option<TimeEntry> {
             true => {
                 println!("{}", "Operation cancelled".red());
                 Vec::new()
-            },
+            }
             false => output.selected_items,
         })
         .map(|selected_items| {

--- a/src/commands/cont.rs
+++ b/src/commands/cont.rs
@@ -87,9 +87,7 @@ fn get_first_stopped_time_entry(
         None => 0,
         _ => 1,
     };
-    return time_entries
-        .get(continue_entry_index)
-        .map(|time_entry| time_entry.clone());
+    return time_entries.get(continue_entry_index).cloned();
 }
 
 fn get_time_entry_from_user(time_entries: Vec<TimeEntry>) -> Option<TimeEntry> {
@@ -122,7 +120,7 @@ fn get_time_entry_from_user(time_entries: Vec<TimeEntry>) -> Option<TimeEntry> {
             Some(time_entry_id) => time_entries
                 .iter()
                 .find(|time_entry| time_entry.id == time_entry_id)
-                .map(|time_entry| time_entry.clone()),
+                .cloned(),
             _ => None,
         })
 }

--- a/src/commands/cont.rs
+++ b/src/commands/cont.rs
@@ -2,13 +2,34 @@ use crate::api;
 use crate::models;
 use api::ApiClient;
 use chrono::Utc;
+use colored::control;
 use colored::Colorize;
-use models::{ResultWithDefaultError,TimeEntry};
+use models::{ResultWithDefaultError, TimeEntry};
+use skim::prelude::*;
 
 pub struct ContinueCommand;
 
+impl SkimItem for TimeEntry {
+    fn text(&self) -> Cow<str> {
+        // Wrap text calculation in this block
+        // to disable outputing the color keycodes
+        // since the filter window doesn't support them
+        control::set_override(false);
+        let self_as_plainstring = Cow::from(self.to_string());
+        control::unset_override();
+        self_as_plainstring
+    }
+
+    fn output(&self) -> Cow<str> {
+        Cow::from(self.id.to_string())
+    }
+}
+
 impl ContinueCommand {
-    pub async fn execute(api_client: impl ApiClient, interactive: bool) -> ResultWithDefaultError<()> {
+    pub async fn execute(
+        api_client: impl ApiClient,
+        interactive: bool,
+    ) -> ResultWithDefaultError<()> {
         let running_entry_stop_time = Utc::now();
         let running_time_entry = api_client.get_running_time_entry().await?;
         if let Some(time_entry) = &running_time_entry {
@@ -42,11 +63,59 @@ impl ContinueCommand {
     }
 }
 
-fn get_time_to_continue(time_entries: Vec<TimeEntry>, running_time_entry: Option<TimeEntry>, interactive: bool) -> Option<TimeEntry> {
+fn get_time_to_continue(
+    time_entries: Vec<TimeEntry>,
+    running_time_entry: Option<TimeEntry>,
+    interactive: bool,
+) -> Option<TimeEntry> {
+    match interactive {
+        true => get_time_entry_from_user(time_entries),
+        false => get_first_stopped_time_entry(time_entries, running_time_entry),
+    }
+}
+
+fn get_first_stopped_time_entry(
+    time_entries: Vec<TimeEntry>,
+    running_time_entry: Option<TimeEntry>,
+) -> Option<TimeEntry> {
     // Don't continue a running entry that was just stopped.
     let continue_entry_index = match running_time_entry {
         None => 0,
         _ => 1,
     };
-    return time_entries.get(continue_entry_index).map(|time_entry| time_entry.clone());
+    return time_entries
+        .get(continue_entry_index)
+        .map(|time_entry| time_entry.clone());
+}
+
+fn get_time_entry_from_user(time_entries: Vec<TimeEntry>) -> Option<TimeEntry> {
+    let options = SkimOptionsBuilder::default()
+        .height(Some("100%"))
+        .multi(false)
+        .build()
+        .unwrap();
+
+    let (sender, source): (SkimItemSender, SkimItemReceiver) = unbounded();
+    time_entries.iter().for_each(|time_entry| {
+        let _ = sender.send(Arc::new(time_entry.clone()));
+    });
+    drop(sender);
+
+    Skim::run_with(&options, Some(source))
+        .map(|output| match output.is_abort {
+            true => Vec::new(),
+            false => output.selected_items,
+        })
+        .map(|selected_items| {
+            selected_items
+                .first()
+                .map(|item| item.output().parse::<i64>().unwrap())
+        })
+        .and_then(|selected_time_entry_id| match selected_time_entry_id {
+            Some(time_entry_id) => time_entries
+                .iter()
+                .find(|time_entry| time_entry.id == time_entry_id)
+                .map(|time_entry| time_entry.clone()),
+            _ => None,
+        })
 }

--- a/src/commands/cont.rs
+++ b/src/commands/cont.rs
@@ -2,28 +2,10 @@ use crate::api;
 use crate::models;
 use api::ApiClient;
 use chrono::Utc;
-use colored::control;
 use colored::Colorize;
 use models::{ResultWithDefaultError, TimeEntry};
-use skim::prelude::*;
 
 pub struct ContinueCommand;
-
-impl SkimItem for TimeEntry {
-    fn text(&self) -> Cow<str> {
-        // Wrap text calculation in this block
-        // to disable outputing the color keycodes
-        // since the filter window doesn't support them
-        control::set_override(false);
-        let self_as_plainstring = Cow::from(self.to_string());
-        control::unset_override();
-        self_as_plainstring
-    }
-
-    fn output(&self) -> Cow<str> {
-        Cow::from(self.id.to_string())
-    }
-}
 
 impl ContinueCommand {
     pub async fn execute(
@@ -74,7 +56,7 @@ fn get_time_entry_to_continue(
     interactive: bool,
 ) -> Option<TimeEntry> {
     if interactive {
-        get_time_entry_from_user(time_entries)
+        autocomplete::get_time_entry_from_user(time_entries)
     } else {
         get_first_stopped_time_entry(time_entries, running_time_entry)
     }
@@ -92,48 +74,83 @@ fn get_first_stopped_time_entry(
     return time_entries.get(continue_entry_index).cloned();
 }
 
-fn get_time_entry_from_user(time_entries: Vec<TimeEntry>) -> Option<TimeEntry> {
-    let (options, source) = get_skim_configuration(time_entries.clone());
-    Skim::run_with(&options, Some(source))
-        .map(|output| {
-            if output.is_abort {
-                println!("{}", "Operation cancelled".red());
-                Vec::new()
-            } else {
-                output.selected_items
-            }
-        })
-        .map(|selected_items| {
-            selected_items
-                .first()
-                .map(|item| item.output().parse::<i64>().unwrap())
-        })
-        .and_then(|selected_time_entry_id| match selected_time_entry_id {
-            Some(time_entry_id) => time_entries
-                .iter()
-                .find(|time_entry| time_entry.id == time_entry_id)
-                .cloned(),
-            _ => None,
-        })
+#[cfg(not(unix))]
+mod autocomplete {
+    use super::*;
+
+    pub fn get_time_entry_from_user(_time_entries: Vec<TimeEntry>) -> Option<TimeEntry> {
+        panic!(
+            "{}",
+            "Interactive continue is currently not supported on Windows".red()
+        )
+    }
 }
 
-fn get_skim_configuration(
-    time_entries: Vec<TimeEntry>,
-) -> (SkimOptions<'static>, SkimItemReceiver) {
-    let options = SkimOptionsBuilder::default()
-        // Set viewport to take entire screen
-        .height(Some("100%"))
-        // Disable multiselect
-        .multi(false)
-        .build()
-        .unwrap();
+#[cfg(unix)]
+mod autocomplete {
+    use super::*;
+    use colored::control;
+    use skim::prelude::*;
 
-    let (sender, source): (SkimItemSender, SkimItemReceiver) = unbounded();
-    for time_entry in time_entries {
-        // Send time-entries to Skim receiver
-        let _ = sender.send(Arc::new(time_entry.clone()));
+    impl SkimItem for TimeEntry {
+        fn text(&self) -> Cow<str> {
+            // Wrap text calculation in this block
+            // to disable outputing the color keycodes
+            // since the filter window doesn't support them
+            control::set_override(false);
+            let self_as_plainstring = Cow::from(self.to_string());
+            control::unset_override();
+            self_as_plainstring
+        }
+
+        fn output(&self) -> Cow<str> {
+            Cow::from(self.id.to_string())
+        }
     }
-    // Complete sender transaction to signal no new items will be added after this
-    drop(sender);
-    (options, source)
+
+    pub fn get_time_entry_from_user(time_entries: Vec<TimeEntry>) -> Option<TimeEntry> {
+        let (options, source) = get_skim_configuration(time_entries.clone());
+        Skim::run_with(&options, Some(source))
+            .map(|output| {
+                if output.is_abort {
+                    println!("{}", "Operation cancelled".red());
+                    Vec::new()
+                } else {
+                    output.selected_items
+                }
+            })
+            .map(|selected_items| {
+                selected_items
+                    .first()
+                    .map(|item| item.output().parse::<i64>().unwrap())
+            })
+            .and_then(|selected_time_entry_id| match selected_time_entry_id {
+                Some(time_entry_id) => time_entries
+                    .iter()
+                    .find(|time_entry| time_entry.id == time_entry_id)
+                    .cloned(),
+                _ => None,
+            })
+    }
+
+    fn get_skim_configuration(
+        time_entries: Vec<TimeEntry>,
+    ) -> (SkimOptions<'static>, SkimItemReceiver) {
+        let options = SkimOptionsBuilder::default()
+            // Set viewport to take entire screen
+            .height(Some("100%"))
+            // Disable multiselect
+            .multi(false)
+            .build()
+            .unwrap();
+
+        let (sender, source): (SkimItemSender, SkimItemReceiver) = unbounded();
+        for time_entry in time_entries {
+            // Send time-entries to Skim receiver
+            let _ = sender.send(Arc::new(time_entry.clone()));
+        }
+        // Complete sender transaction to signal no new items will be added after this
+        drop(sender);
+        (options, source)
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -39,7 +39,7 @@ pub async fn execute_subcommand(command: Option<Command>) -> ResultWithDefaultEr
         None => RunningTimeEntryCommand::execute(get_api_client()?).await?,
         Some(subcommand) => match subcommand {
             Stop => StopCommand::execute(get_api_client()?).await?,
-            Continue => ContinueCommand::execute(get_api_client()?).await?,
+            Continue { interactive }  => ContinueCommand::execute(get_api_client()?, interactive).await?,
             List { number } => ListCommand::execute(get_api_client()?, number).await?,
             Current | Running => RunningTimeEntryCommand::execute(get_api_client()?).await?,
             Start {

--- a/src/main.rs
+++ b/src/main.rs
@@ -39,7 +39,9 @@ pub async fn execute_subcommand(command: Option<Command>) -> ResultWithDefaultEr
         None => RunningTimeEntryCommand::execute(get_api_client()?).await?,
         Some(subcommand) => match subcommand {
             Stop => StopCommand::execute(get_api_client()?).await?,
-            Continue { interactive }  => ContinueCommand::execute(get_api_client()?, interactive).await?,
+            Continue { interactive } => {
+                ContinueCommand::execute(get_api_client()?, interactive).await?
+            }
             List { number } => ListCommand::execute(get_api_client()?, number).await?,
             Current | Running => RunningTimeEntryCommand::execute(get_api_client()?).await?,
             Start {


### PR DESCRIPTION
## What does this PR do?

- Use `skim` to integrate fzf like interactive selection
  -  `skim` seems really unpolished atm, support for generic/custom elements is very rough
  - We can't get an index of the selected result back.
  - The downcast examples mentioned in https://github.com/lotabout/skim/blob/6df015987934bd63121be53d8659da0f44237dac/src/lib.rs#L90-L100 caused panic on execution for me, if either of you can get it to work, we can skip doing an additional pass on the array to match the TE id.
- Tests, I saw the skim repo for test examples, it's doable but I'm kind of burned out on this particular PR for now, and would prefer doing it as a follow-up.
- See it in action

https://user-images.githubusercontent.com/1716853/123015365-7f718c80-d3c8-11eb-9187-1408f81fdaa5.mov


## Issues

Closes #10 