### PR TITLE
🖥️ Add all supported platforms to CI

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -12,7 +12,13 @@ env:
 jobs:
   check:
     name: Check
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os:
+          - ubuntu-latest
+          - macOS-latest
+          - windows-latest
     steps:
       - name: Checkout sources
         uses: actions/checkout@v2


### PR DESCRIPTION
While testing #26 I noticed that it simply won't build on Windows (😢) and CI didn't catch it because it was running on Ubuntu only.

This mitigates that problem